### PR TITLE
hacky semi-fix, won't add mouse to input field

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,8 @@
       <div class="large-12 columns">
         <h3> Hobbyist </h3>
 
+
+
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), :html => {'data-abide' => ''}) do |f| %>
 
         <form>
@@ -21,21 +23,21 @@
 
           <div class="row">
             <div class="large-12 columns">
-              <%= f.text_field :username, autofocus: true, placeholder: :username, required: true %>
+              <%= f.text_field :username, placeholder: :username, required: true %>
               <small class="error">Username is required.</small>
             </div>
           </div>
 
           <div class="row">
             <div class="large-12 columns">
-              <%= f.email_field :email, autofocus: true, placeholder: :email, required: true %>
+              <%= f.email_field :email, placeholder: :email, required: true %>
               <small class="error">An email address is required.</small>
             </div>
           </div>
 
           <div class="row">
             <div class="large-12 columns">
-              <%= f.password_field :password, autocomplete: "off", placeholder: :"minimum of 8 characters", required: true  %>
+              <%= f.password_field :password, autocomplete: "off", placeholder: :"minimum of 8 characters", required: true %>
               <small class="error">Password is required.</small>
             </div>
           </div>


### PR DESCRIPTION
won't show error message because mouse no longer on input field. however, if mouse is put on the input field, and then you click away, the error message will show.
